### PR TITLE
PEP668 causes an error virtualenv for ESP-IDF #1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,6 +94,12 @@ RUN apt update && \
     apt clean && rm -rf /var/lib/apt/lists/*
 
 USER $user
+
+# Install virtualenv with `break-system-packages`
+#
+# refs: https://github.com/matsudai/mrubyc-builder/issues/1
+RUN /usr/bin/python3 -m pip install --user virtualenv --break-system-packages
+
 RUN mkdir -p ~/esp && \
     cd ~/esp && \
     git clone --recursive --shallow-submodules --branch release/v4.2 --depth 1 https://github.com/espressif/esp-idf.git && \


### PR DESCRIPTION
`install.sh` calls `pip install virtualenv` .
But PEP668 cannot system packages are unbreakable without `--break-system-packages` .